### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,13 @@ on:
       - 'phpunit.xml.dist'
       - 'composer.json'
       - 'composer.lock'
+  pull_request:
+    paths:
+      - '**.php'
+      - '.github/workflows/run-tests.yml'
+      - 'phpunit.xml.dist'
+      - 'composer.json'
+      - 'composer.lock'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,15 +28,16 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        php: [ 8.4, 8.3 ]
-        laravel: [ 12.*, 11.* ]
+        php: [ 8.5, 8.4, 8.3 ]
+        laravel: [ 13.*, 12.*, 11.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
-
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,22 +16,22 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "guzzlehttp/guzzle": "^7.7",
-        "illuminate/contracts": "^11.0||^12.0",
+        "illuminate/contracts": "^11.0||^12.0||^13.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
-        "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "larastan/larastan": "^2.9||^3.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
-        "pestphp/pest": "^2.0||^3.0",
-        "pestphp/pest-plugin-arch": "^2.5||^3.0",
-        "pestphp/pest-plugin-laravel": "^2.0||^3.0",
-        "phpstan/extension-installer": "^1.3||^2.0",
-        "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
-        "phpstan/phpstan-phpunit": "^1.3||^2.0",
+        "nunomaduro/collision": "^8.8",
+        "larastan/larastan": "^3.0",
+        "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
+        "pestphp/pest": "^3.0||^4.0",
+        "pestphp/pest-plugin-arch": "^3.0||^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0||^4.0",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
         "spatie/laravel-ray": "^1.35"
     },
     "autoload": {


### PR DESCRIPTION
## Summary

- Adds Laravel 13 to `illuminate/contracts` constraint (`^11.0||^12.0||^13.0`)
- Adds `orchestra/testbench ^11.0.0` (testbench 11 maps to Laravel 13)
- Bumps PHP minimum from `^8.2` to `^8.3`
- Updates dev dependencies to current major versions (pest 4, larastan 3, phpstan 2)
- Extends CI matrix to cover PHP 8.5 and Laravel 13.* with `prefer-lowest` and `prefer-stable`
- Adds missing `pull_request` trigger to the run-tests workflow

## Test plan

- [ ] CI passes across the full matrix (PHP 8.3/8.4/8.5 × Laravel 11/12/13 × prefer-lowest/prefer-stable)
- [ ] `composer update --prefer-lowest` resolves without conflicts
- [ ] `vendor/bin/pest --ci` passes locally against Laravel 13

🤖 Generated with [Claude Code](https://claude.com/claude-code)