### PR TITLE
Update GitHub Actions workflow versions

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
 
@@ -24,7 +24,7 @@ jobs:
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: main
           commit_message: Update CHANGELOG

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ vendor
 node_modules
 
 .phpunit.result.cache
+
+.claude/


### PR DESCRIPTION
## Summary

- **phpstan.yml**: Bump PHP from `8.2` → `8.3` — the project requires `^8.3`, so running static analysis on an unsupported version was a mismatch.
- **update-changelog.yml**: Upgrade `actions/checkout` from `v3` → `v4` and `stefanzweifel/git-auto-commit-action` from `v4` → `v5` — brings this workflow in line with the other workflows in the repo that already use the newer versions.

## Reviewer notes

- `run-tests.yml` was already up to date (Laravel 13 / PHP 8.3–8.5 matrix was added in #51).
- No functional behaviour changes — these are action version bumps and a PHP version correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)