### PR TITLE
Updates PHP version requirements and adds type hints to HTTP logging

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,13 +36,14 @@ jobs:
             testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
-
+          - laravel: 11.*
+            testbench: 9.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,16 +28,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.5, 8.4, 8.3 ]
-        laravel: [ 13.*, 12.*, 11.* ]
+        php: [ 8.5, 8.4 ]
+        laravel: [ 13.*, 12.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 13.*
             testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
-          - laravel: 11.*
-            testbench: 9.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest ]
         php: [ 8.5, 8.4, 8.3 ]
         laravel: [ 13.*, 12.*, 11.* ]
         stability: [ prefer-lowest, prefer-stable ]
@@ -36,8 +36,7 @@ jobs:
             testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
-          - laravel: 11.*
-            testbench: 9.*
+
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "guzzlehttp/guzzle": "^7.7",
         "illuminate/contracts": "^11.0||^12.0||^13.0",
         "spatie/laravel-package-tools": "^1.16"
@@ -26,9 +26,9 @@
         "nunomaduro/collision": "^8.8",
         "larastan/larastan": "^3.0",
         "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
-        "pestphp/pest": "^3.0||^4.0",
-        "pestphp/pest-plugin-arch": "^3.0||^4.0",
-        "pestphp/pest-plugin-laravel": "^3.0||^4.0",
+        "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-arch": "^4.0",
+        "pestphp/pest-plugin-laravel": "^4.0",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,13 +20,6 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>

--- a/src/HttpLogging.php
+++ b/src/HttpLogging.php
@@ -2,6 +2,7 @@
 
 namespace RobMellett\HttpLogging;
 
+use Closure;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Psr\Http\Message\RequestInterface;
@@ -16,14 +17,14 @@ class HttpLogging
     protected readonly string $channel;
 
     public function __construct(
-        private readonly array $config = []
+        public readonly array $config = []
     ) {
         $this->channel = $config['channel'] ?? config('http-logging.channel');
     }
 
-    public function __invoke(callable $handler)
+    public function __invoke(callable $handler): Closure
     {
-        $uuid = app(Str::class)->uuid();
+        $uuid = (string) app(Str::class)->uuid();
 
         return function (RequestInterface $request, array $options) use ($handler, $uuid) {
             $this->logRequest($uuid, $request);
@@ -51,7 +52,7 @@ class HttpLogging
                     'query' => $request->getUri()->getQuery(),
                 ],
                 'headers' => $request->getHeaders(),
-                'body' => json_decode($request->getBody(), true),
+                'body' => json_decode((string) $request->getBody(), true),
             ]);
         } catch (Throwable $throwable) {
             report($throwable);
@@ -65,7 +66,7 @@ class HttpLogging
                 'response_id' => $uuid,
                 'status_code' => $response->getStatusCode(),
                 'headers' => $response->getHeaders(),
-                'body' => json_decode($response->getBody(), true),
+                'body' => json_decode((string) $response->getBody(), true),
             ]);
         } catch (Throwable $throwable) {
             report($throwable);


### PR DESCRIPTION
- Upgrades PHP version requirements from 8.3 to 8.4 in workflow files and composer.json to stay current with supported PHP versions.  
- Simplifies test matrix by removing Windows runs, improving CI efficiency.  
- Updates Pest testing packages to require only version 4.x for consistency.  
- Adds explicit type hints and safer casting in HTTP logging middleware to improve code clarity and robustness.  
- Casts request and response bodies to strings before JSON decoding to avoid potential errors.  

No changes to `.env.example` variables or npm packages.

These improvements ensure better type safety, streamlined CI workflows, and up-to-date dependency constraints.